### PR TITLE
Validacion del correo unimet y mejoras de inicio de sesion

### DIFF
--- a/src/Login.jsx
+++ b/src/Login.jsx
@@ -32,17 +32,25 @@ export default function Login() {
   const handleSubmit = async (e) => {
     e.preventDefault();
     setMessage("");
+    const redirectTo = import.meta.env.DEV
+    ? 'http://localhost:5173'
+    : `${window.location.origin}/auth/callback`;
     const { error } = await supabase.auth.signInWithPassword({
       email: form.email,
       password: form.password,
+      options: { redirectTo }
     });
     if (error) return setMessage(`Error: ${error.message}`);
     setMessage("Login exitoso, redirigiendo...");
   };
 
   const handleGoogleLogin = async () => {
+    const redirectTo = import.meta.env.DEV
+    ? 'http://localhost:5173'
+    : `${window.location.origin}/auth/callback`;
     const { error } = await supabase.auth.signInWithOAuth({
       provider: "google",
+      options: { redirectTo }
     });
     if (error) setMessage(`Error con Google: ${error.message}`);
   };

--- a/src/Register.jsx
+++ b/src/Register.jsx
@@ -34,6 +34,14 @@ export default function Register() {
   const handleSubmit = async (e) => {
     e.preventDefault();
     setMessage("");
+
+    // Validar que el correo sea institucional (Unimet)
+    const correoValido = /^[a-zA-Z0-9._%+-]+@correo\.unimet\.edu\.ve$/.test(form.email);
+    if (!correoValido) {
+      setMessage("Solo se permite correo institucional (@correo.unimet.edu.ve)");
+      return;
+    }
+
     const { error } = await supabase.auth.signUp({
       email: form.email,
       password: form.password,
@@ -54,13 +62,14 @@ export default function Register() {
   };
 
   const handleGoogleRegister = async () => {
+    const redirectTo = import.meta.env.DEV
+    ? 'http://localhost:5173'
+    : `${window.location.origin}/auth/callback`;
     const { error } = await supabase.auth.signInWithOAuth({
       provider: "google",
+      options: { redirectTo }
     });
-    if (error) {
-      console.error("Error con Google:", error.message);
-      setMessage(`Error con Google: ${error.message}`);
-    }
+    if (error) setMessage(`Error con Google: ${error.message}`);
   };
 
   //  Renderizado de la interfaz de usuario
@@ -106,6 +115,7 @@ export default function Register() {
             onChange={handleChange}
             required
             className="input-field"
+            placeholder="ejemplo@correo.unimet.edu.ve"
           />
         </div>
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,7 +3,7 @@ import { supabase } from "./config/supabase";
 // Verifica si el usuario tiene una sesion activa
 export async function verificar_sesion(){
     const { data, error} = await supabase.auth.getSession();
-
+    
     if (data.session) {
         console.log("Sesion activa", data.session.user);
         return true;


### PR DESCRIPTION
Se agrego una validación al registrarse para que el correo solo pueda ser de institucional de la Unimet ( ejemplo@correo.unimet.edu.ve ).

Ademas se cambiaron algunos parametros en la autenticacion con fines de desarrollo.